### PR TITLE
WebDav Response Namespace not always 'D'

### DIFF
--- a/AFWebDAVManager/AFWebDAVManager.h
+++ b/AFWebDAVManager/AFWebDAVManager.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSUInteger, AFWebDAVLockScope) {
  */
 - (void)contentsOfDirectoryAtURLString:(NSString *)URLString
                              recursive:(BOOL)recursive
-                     completionHandler:(void (^)(NSArray *items, NSError *error))completionHandler;
+                     completionHandler:(void (^)(NSArray *items, AFHTTPRequestOperation *operation, NSError *error))completionHandler;
 
 /**
  Creates a directory at the path represented by the specified URL string.

--- a/AFWebDAVManager/AFWebDAVManager.m
+++ b/AFWebDAVManager/AFWebDAVManager.m
@@ -85,15 +85,15 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
 
 - (void)contentsOfDirectoryAtURLString:(NSString *)URLString
                              recursive:(BOOL)recursive
-                     completionHandler:(void (^)(NSArray *items, NSError *error))completionHandler
+                     completionHandler:(void (^)(NSArray *items, AFHTTPRequestOperation *operation, NSError *error))completionHandler
 {
     [self PROPFIND:URLString propertyNames:nil depth:(recursive ? AFWebDAVInfinityDepth : AFWebDAVOneDepth) success:^(__unused AFHTTPRequestOperation *operation, id responseObject) {
         if (completionHandler) {
-            completionHandler(responseObject, nil);
+            completionHandler(responseObject, operation, nil);
         }
     } failure:^(__unused AFHTTPRequestOperation *operation, NSError *error) {
         if (completionHandler) {
-            completionHandler(nil, error);
+            completionHandler(nil, operation, error);
         }
     }];
 }
@@ -217,7 +217,7 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
 - (void)contentsOfFileAtURLString:(NSString *)URLString
                 completionHandler:(void (^)(NSData *contents, NSError *error))completionHandler
 {
-    [self GET:URLString parameters:nil success:^(AFHTTPRequestOperation *operation, __unused id responseObject) {
+    AFHTTPRequestOperation *operation = [self GET:URLString parameters:nil success:^(AFHTTPRequestOperation *operation, __unused id responseObject) {
         if (completionHandler) {
             completionHandler(operation.responseData, nil);
         }
@@ -225,6 +225,9 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
         if (completionHandler) {
             completionHandler(nil, error);
         }
+    }];
+    [operation setDownloadProgressBlock:^(NSUInteger bytesRead, long long totalBytesRead, long long totalBytesExpectedToRead) {
+        NSLog(@"%lu ----- %lld ------ %lld", (unsigned long)bytesRead, totalBytesRead, totalBytesExpectedToRead);
     }];
 }
 

--- a/AFWebDAVManager/AFWebDAVManager.m
+++ b/AFWebDAVManager/AFWebDAVManager.m
@@ -293,7 +293,7 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
 
     NSMutableURLRequest *request = [self.requestSerializer requestWithMethod:@"PROPFIND" URLString:[[self.baseURL URLByAppendingPathComponent:URLString] absoluteString] parameters:nil error:nil];
 	[request setValue:AFWebDAVStringForDepth(depth) forHTTPHeaderField:@"Depth"];
-    [request setValue:@"application/xml" forHTTPHeaderField:@"Content-Type:"];
+    [request setValue:@"application/xml" forHTTPHeaderField:@"Content-Type"];
     [request setHTTPBody:[mutableXMLString dataUsingEncoding:NSUTF8StringEncoding]];
 
     AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];

--- a/AFWebDAVManager/AFWebDAVManager.m
+++ b/AFWebDAVManager/AFWebDAVManager.m
@@ -532,8 +532,8 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
 - (instancetype)initWithResponseElement:(ONOXMLElement *)element {
     NSParameterAssert(element);
 
-    NSString *href = [[element firstChildWithTag:@"href" inNamespace:@"D"] stringValue];
-    NSInteger status = [[[element firstChildWithTag:@"status" inNamespace:@"D"] numberValue] integerValue];
+    NSString *href = [[element firstChildWithTag:@"href"] stringValue];
+    NSInteger status = [[[element firstChildWithTag:@"status"] numberValue] integerValue];
 
     self = [self initWithURL:[NSURL URLWithString:href] statusCode:status HTTPVersion:@"HTTP/1.1" headerFields:nil];
     if (!self) {
@@ -548,9 +548,9 @@ static NSString * AFWebDAVStringForLockType(AFWebDAVLockType type) {
         }
     }
 
-    self.contentLength = [[[propElement firstChildWithTag:@"getcontentlength" inNamespace:@"D"] numberValue] unsignedIntegerValue];
-    self.creationDate = [[propElement firstChildWithTag:@"creationdate" inNamespace:@"D"] dateValue];
-    self.lastModifiedDate = [[propElement firstChildWithTag:@"getlastmodified" inNamespace:@"D"] dateValue];
+    self.contentLength = [[[propElement firstChildWithTag:@"getcontentlength"] numberValue] unsignedIntegerValue];
+    self.creationDate = [[propElement firstChildWithTag:@"creationdate"] dateValue];
+    self.lastModifiedDate = [[propElement firstChildWithTag:@"getlastmodified"] dateValue];
 
     return self;
 }

--- a/BPWebDAVManager.podspec
+++ b/BPWebDAVManager.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
-  s.name         = "AFWebDAVManager"
+  s.name         = "BPWebDAVManager"
   s.version      = "0.0.1"
   s.summary      = "AFNetworking extension for WebDAV"
   s.homepage     = "https://github.com/AFNetworking/AFWebDAVManager"
   s.social_media_url = "https://twitter.com/AFNetworking"
   s.license      = 'MIT'
   s.author       = { "Mattt Thompson" => "m@mattt.me" }
-  s.source       = { :git => "https://github.com/AFNetworking/AFWebDAVManager.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/BitSuites/AFWebDAVManager.git", :tag => "0.0.1" }
 
   s.source_files = 'AFWebDAVManager'
   s.requires_arc = true


### PR DESCRIPTION
I removed the inNamespace:@"D" for the AFWebDAVMultiStatusResponse because the response does not always use the "D" Namespace I found that Microsoft servers use the namespace "a".  Information on Microsoft webdav https://msdn.microsoft.com/en-us/library/ms879496(v=exchg.65).aspx

I testested with an "a" namespace and a "D" namespace server and there were no issues.
